### PR TITLE
Add optional object to insertEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.1",
+    "deepmerge": "^1.3.2",
     "google-oauth-jwt": "^0.2.0",
     "request-promise": "^4.1.0"
   },

--- a/src/CalendarAPI.js
+++ b/src/CalendarAPI.js
@@ -1,6 +1,8 @@
 const Promise = require('bluebird');
 const requestWithJWT = Promise.promisify(require('google-oauth-jwt').requestWithJWT());
 const qs = require('querystring');
+const deepmerge = require('deepmerge');
+
 class CalendarAPI {
 
   constructor(config) {
@@ -73,7 +75,7 @@ class CalendarAPI {
    * @param {string} location - Location description of event
    * @param {string} status - event status - confirmed, tentative, cancelled; tentative for all queuing
    */
-  insertEvent(calendarId, eventSummary, startDateTime, endDateTime, location, status, description, colour) {
+  insertEvent(calendarId, eventSummary, startDateTime, endDateTime, location, status, description, colour, additionalOptions) {
     this._checkCalendarId(calendarId);
     let event = {
       "start": {
@@ -89,11 +91,13 @@ class CalendarAPI {
       "colorId": colour,
     };
 
+    const eventWithAdditionalOptions = additionalOptions ? deepmerge(event, additionalOptions) : event;
+
     let options = {
       method: 'POST',
       url: 'https://www.googleapis.com/calendar/v3/calendars/' + calendarId + '/events',
       json: true,
-      body: event,
+      body: eventWithAdditionalOptions,
       jwt: this._JWT
     };
 


### PR DESCRIPTION
Passing additionalOptions allows consumers to add other api values into their request.
I originally wanted to do a Object.assign but this was not a deep enough merge.
Adding the deepmerge library prevented any other the original params being deleted.