### PR TITLE
Added Event.patch

### DIFF
--- a/src/Events.js
+++ b/src/Events.js
@@ -250,6 +250,34 @@ class Events {
 			});
 	}
 
+	
+	
+	/** Patches an event on the calendar specified. Returns promise of details of patched event
+	 *
+	 * @param {string} calendarId 					- Calendar identifier
+	 * @param {string} eventId 						- EventId specifying event to update
+	 */
+	patch(calendarId, eventId, params, query) {
+		let checkResult = this._checkCalendarAndEventId(calendarId, eventId, 'Events.patch');
+		if (undefined !== checkResult) {
+			return checkResult;
+		}
+		
+		return this._httpRequest.patch(`${this._gcalBaseUrl}${calendarId}/events/${eventId}`, params, this._JWT, query)
+			.then(resp => {
+				this._checkErrorResponse(200, resp.statusCode, resp.body, resp.statusMessage);
+				let body = typeof resp.body === 'string' ? JSON.parse(resp.body) : resp.body;
+				return body;
+			})
+			.catch(err => {
+				let error = {
+					origin: 'Events.patch',
+					error: this._tryParseJSON(err.message)		// return as object if JSON, string if not parsable
+				};
+				throw new Error(JSON.stringify(error));
+			});
+	}
+
 	/** Updates an event on the calendar specified. Returns promise of details of updated event
 	 *
 	 * @param {string} calendarId 					- Calendar identifier

--- a/src/HttpRequest.js
+++ b/src/HttpRequest.js
@@ -77,6 +77,21 @@ class HttpRequest {
 
 		return requestWithJWT(options);
 	}
+	
+	patch(url, params, jwt, query) {
+		this._checkRequired(url, params, jwt);
+
+		let options = {
+			method: 'PATCH',
+			url: url,
+			jwt: jwt,
+			body: params,
+			qs: query,
+			json: true
+		};
+
+		return requestWithJWT(options);
+	}
 
 	delete(url, params, jwt) {
 		this._checkBasicRequired(url, jwt);


### PR DESCRIPTION
Description: 
Added https://developers.google.com/calendar/v3/reference/events/patch
Let´s you PATCH(update) specific params of the event without messing with the others params.

For instance: You want to patch/update the event summary
     let event = {
         'summary':  "Some new summary"
    };
        
    cal.Events.patch(calendarId, eventId, event)
         .then(resp => {
            console.log('patched event:');
            console.log(resp);
        })
         .catch(err => {
            console.log('err', err)
            console.log('Error: patchEvent-' + err.message);
        });